### PR TITLE
Matrix data is now a contiguous piece of memory

### DIFF
--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -6,7 +6,7 @@ use rand::{thread_rng, Rng};
 pub struct Matrix {
     pub rows: usize,
     pub cols: usize,
-    pub data: Vec<Vec<f64>>,
+    pub data: Vec<f64>,
 }
 
 impl Matrix {
@@ -16,7 +16,24 @@ impl Matrix {
         Self {
             rows,
             cols,
-            data: vec![vec![0.0; cols]; rows],
+            data: vec![0.0; cols * rows],
+        }
+    }
+
+    /// Create a row * col matrix with
+    /// given data
+    pub fn from_parts(rows: usize, cols: usize, data: Vec<f64>) -> Self {
+        debug_assert_eq!(rows * cols, data.len());
+        Self { rows, cols, data }
+    }
+
+    /// Create a row metrix with
+    /// given data
+    pub fn row(data: Vec<f64>) -> Self {
+        Self {
+            rows: 1,
+            cols: data.len(),
+            data,
         }
     }
 
@@ -118,12 +135,10 @@ impl Matrix {
     /// Takes a closure and creates an iterator which calls that closure on each
     /// element.
     pub fn map(&self, func: impl Fn(f64) -> f64) -> Self {
-        Matrix::from(
-            self.data
-                .clone()
-                .into_iter()
-                .map(|i| i.into_iter().map(|i| func(i)).collect())
-                .collect::<Vec<Vec<_>>>(),
+        Matrix::from_parts(
+            self.rows,
+            self.cols,
+            self.data.iter().map(|i| func(*i)).collect::<Vec<_>>(),
         )
     }
 
@@ -140,25 +155,17 @@ impl Matrix {
     }
 }
 
-impl From<Vec<Vec<f64>>> for Matrix {
-    fn from(value: Vec<Vec<f64>>) -> Self {
-        Self {
-            rows: value.len(),
-            cols: value.first().and_then(|i| Some(i.len())).unwrap_or(0),
-            data: value,
-        }
-    }
-}
-
 impl Index<usize> for Matrix {
     type Output = [f64];
     fn index(&self, index: usize) -> &Self::Output {
-        &self.data[index]
+        let start = index * self.cols;
+        &self.data[start..start + self.cols]
     }
 }
 
 impl IndexMut<usize> for Matrix {
     fn index_mut(&mut self, index: usize) -> &mut Self::Output {
-        &mut self.data[index]
+        let start = index * self.cols;
+        &mut self.data[start..start + self.cols]
     }
 }

--- a/src/network.rs
+++ b/src/network.rs
@@ -49,7 +49,7 @@ impl<'a> Network<'a> {
             panic!("Invalid number of inputs");
         }
 
-        let mut current = Matrix::from(vec![inputs]).transpose();
+        let mut current = Matrix::row(inputs).transpose();
         self.data = vec![current.clone()];
 
         for i in 0..self.layers.len() - 1 {
@@ -69,8 +69,8 @@ impl<'a> Network<'a> {
             panic!("Invalid number of targets");
         }
 
-        let parsed = Matrix::from(vec![outputs]);
-        let mut errors = Matrix::from(vec![targets]).sub(&parsed);
+        let parsed = Matrix::row(outputs);
+        let mut errors = Matrix::row(targets).sub(&parsed);
         let mut gradients = parsed.map(self.activation.derivative);
 
         for i in (0..self.layers.len() - 1).rev() {


### PR DESCRIPTION
Matrix data is now a contiguous piece of memory ie. `Vec<f64>` instead of `Vec<Vec<f64>>` with custom implementation of `Index<usize>` and `IndexMut<usize>` for Matrix.
This greatly improves the performance, and also safety of all rows to be the same size

Additional Note: This also allows Iterator implementation for matrix to improve not allocating and copying the matrix while linking operations here:
```rs
current = self.weights[i]
    .mul(&current)
    .add(&self.biases[i])
    .map(self.activation.function);
```